### PR TITLE
Add CRM search CTI configuration

### DIFF
--- a/salesforce/cti/OpenCTI.callCenter-meta.xml
+++ b/salesforce/cti/OpenCTI.callCenter-meta.xml
@@ -31,11 +31,13 @@
   </section>
   <section sortOrder="3" name="outdialData" label="Outdial Configuration">
     <item sortOrder="0" name="outdialRemovePrefix" label="Remove Phone Number Prefix Strings"></item>
+    <item sortOrder="1" name="openCtiEnableCrmSearch" label="Search For CRM records">false</item>
   </section>
   <section sortOrder="4" name="advancedScreenPopData" label="Advanced Screen Pop Search Configuration">
     <item sortOrder="0" name="openCtiEnableAdvancedScreenPop" label="Advanced Screen Pop Enabled">false</item>
     <item sortOrder="1" name="openCtiCadSearchVariable" label="CAD Variable Name"></item>
     <item sortOrder="2" name="openCtiRemoveANIPrefix" label="Remove ANI Prefix Strings"></item>
+    <item sortOrder="3" name="openCtiFallbackToAni" label="Fallback to ANI">false</item>
   </section>
   <section sortOrder="5" name="objectCreationManagement" label="Case Management">
     <item sortOrder="0" name="createObjectIncoming" label="Auto Case Creation For Inbound Calls">false</item>

--- a/salesforce/cti/README.md
+++ b/salesforce/cti/README.md
@@ -14,6 +14,49 @@ This folder contains the Salesforce call center metadata used with the Webex Con
 | --- | --- |
 | [`OpenCTI.callCenter-meta.xml`](./OpenCTI.callCenter-meta.xml) | Salesforce call center definition with Webex Contact Center CTI settings, adapter URL, layout dimensions, and optional behavior flags |
 
+## Configurable call center elements
+
+| Section | Element | Label | Default value |
+| --- | --- | --- | --- |
+| WxCC Settings | `openCtiWxCCRegion` | WxCC Region | eu2 |
+| WxCC Settings | `wxccWebRtcDomain` | WxCC WebRTC Domain | (blank) |
+| General Information | `reqInternalName` | Internal Name | wxCcCallCenter |
+| General Information | `reqDisplayName` | Display Name | WxCC Call Center |
+| General Information | `reqDescription` | Description | Webex Contact Center Salesforce Integration |
+| General Information | `reqAdapterUrl` | CTI Adapter URL | https://wxcc-crmconnectors.ciscoccservice.com/salesforce/connector/v1/index.html |
+| General Information | `reqUseApi` | Use CTI API | true |
+| General Information | `reqSoftphoneHeight` | Softphone Height | 550 |
+| General Information | `reqSoftphoneWidth` | Softphone Width | 400 |
+| General Information | `reqSalesforceCompatibilityMode` | Salesforce Compatibility Mode | Lightning |
+| Call Activity Record Creation | `subjectDateFormat` | Date Format In Subject | MM-DD-YYYY hh:mm a |
+| Call Activity Record Creation | `subjectTemplate` | Subject Template | {direction} Call {activityDatetime} |
+| Call Activity Record Creation | `recordCallLiveNotes` | Record Call Live Notes | true |
+| Call Activity Record Creation | `recordCallLiveSubject` | Record Call Live Subject | true |
+| Call Activity Record Creation | `liveCallNotesFieldMapping` | Live Call Notes Field Mapping | Description |
+| Call Activity Record Creation | `changeActivityRecordOwnership` | Change Activity Record Ownership For Transferred Calls | false |
+| Call Activity Record Creation | `cadVarNameWithActivityId` | CAD Variable Name That Holds Activity Id | (blank) |
+| Call Activity Record Creation | `objectFieldMapping` | Object Field Mappings | (blank) |
+| Call Activity Record Creation | `agentSharedRecord` | Variable for Record Sharing | (blank) |
+| Call Activity Record Creation | `assignActivityToSharedRecord` | Use Activity as Shared Record by default | true |
+| Call Activity Record Creation | `disableActivityRecord` | Disable Activity Record Creation | false |
+| Call Activity Record Creation | `openCtiEnableActivityScreenPopConnected` | Enable Activity Screen Pop on Connected | false |
+| Call Activity Record Creation | `openCtiEnableActivityScreenPopWrapup` | Enable Activity Screen Pop on Wrapup | false |
+| Outdial Configuration | `outdialRemovePrefix` | Remove Phone Number Prefix Strings | (blank) |
+| Outdial Configuration | `openCtiEnableCrmSearch` | Search For CRM records | false |
+| Advanced Screen Pop Search Configuration | `openCtiEnableAdvancedScreenPop` | Advanced Screen Pop Enabled | false |
+| Advanced Screen Pop Search Configuration | `openCtiCadSearchVariable` | CAD Variable Name | (blank) |
+| Advanced Screen Pop Search Configuration | `openCtiRemoveANIPrefix` | Remove ANI Prefix Strings | (blank) |
+| Advanced Screen Pop Search Configuration | `openCtiFallbackToAni` | Fallback to ANI | false |
+| Case Management | `createObjectIncoming` | Auto Case Creation For Inbound Calls | false |
+| Case Management | `createObjectOutgoing` | Auto Case Creation For Outbound calls | false |
+| Case Management | `openInEditMode` | Open Case Object In Edit Mode | false |
+| Case Management | `objectFieldMapping` | Object Field Mappings | (blank) |
+| Screen Pop Settings For No Record Match | `noRecordMatchObjectFieldMappings` | Object Field Mappings | (blank) |
+| Omni-Channel State Sync Configuration | `enableOmniChannelSync` | Enable Omni-Channel Sync | false |
+| Omni-Channel State Sync Configuration | `omniChannelNotReadyReason` | Omni-Channel Not Ready Reason | (blank) |
+| Omni-Channel State Sync Configuration | `wxCCIdleReasonCode` | WxCC Idle Reason Code | (blank) |
+| Widget Settings | `sendBrowserNotifications` | Send Browser Notifications | false |
+
 ## Usage notes
 
 - Import the call center definition into Salesforce as part of the CTI connector setup.


### PR DESCRIPTION
## Summary
- Add CRM search and fallback-to-ANI settings to the Salesforce OpenCTI call center metadata
- Document all configurable call center elements and default values in the Salesforce CTI README

## Validation
- xmllint --noout salesforce/cti/OpenCTI.callCenter-meta.xml
- cmp -s salesforce/cti/OpenCTI.callCenter-meta.xml /Users/arubhatt/Downloads/artifact.tar(1)/callcenter/OpenCTI.callCenter-meta.xml